### PR TITLE
Add Touchstone to Auth Strategies

### DIFF
--- a/userAuth.js
+++ b/userAuth.js
@@ -39,24 +39,23 @@ if (isSlackOauth) {
   ))
 } else if (isTouchstoneSamlAuth) {
   passport.use(new touchstoneSamlStrategy({
-      callbackUrl: callbackURL,
-      entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
-      issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
-      cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
-      privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY,
-      decryptionPvk: process.env.TOUCHSTONE_SAML_DECRYPTION_PRIVATE_KEY,
-      wantAssertionsSigned: true,
-      metadataOrganization: {
-        OrganizationName: {'#text': process.env.TOUCHSTONE_SAML_ORG_NAME},
-        OrganizationDisplayName: {'#text': process.env.TOUCHSTONE_SAML_ORG_DISPLAY_NAME},
-        OrganizationURL: {'#text': process.env.TOUCHSTONE_SAML_ORG_URL}
-      },
-      metadataContactPerson: [{
-        '@contactType': 'support',
-        GivenName: process.env.TOUCHSTONE_SAML_CONTACT_NAME,
-        EmailAddress: process.env.TOUCHSTONE_SAML_CONTACT_EMAIL
-      }]
+    callbackUrl: callbackURL,
+    entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
+    issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
+    cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
+    privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY,
+    decryptionPvk: process.env.TOUCHSTONE_SAML_DECRYPTION_PRIVATE_KEY,
+    wantAssertionsSigned: true,
+    metadataOrganization: {
+      OrganizationName: {'#text': process.env.TOUCHSTONE_SAML_ORG_NAME},
+      OrganizationDisplayName: {'#text': process.env.TOUCHSTONE_SAML_ORG_DISPLAY_NAME},
+      OrganizationURL: {'#text': process.env.TOUCHSTONE_SAML_ORG_URL}
     },
+    metadataContactPerson: [{
+      '@contactType': 'support',
+      GivenName: process.env.TOUCHSTONE_SAML_CONTACT_NAME,
+      EmailAddress: process.env.TOUCHSTONE_SAML_CONTACT_EMAIL
+    }]},
     (profile, done) => done(null, profile)))
 } else {
   // default to google auth

--- a/userAuth.js
+++ b/userAuth.js
@@ -23,7 +23,7 @@ if (!authStrategies.includes(authStrategy)) {
 }
 
 const isSlackOauth = authStrategy === 'Slack'
-const isTouchstoneSamlAuth = authStrategy === "Touchstone"
+const isTouchstoneSamlAuth = authStrategy === 'Touchstone'
 if (isSlackOauth) {
   passport.use(new SlackStrategy({
     clientID: process.env.SLACK_CLIENT_ID,

--- a/userAuth.js
+++ b/userAuth.js
@@ -43,8 +43,7 @@ if (isSlackOauth) {
     entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
     issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
     cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
-    privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY,
-    decryptionPvk: process.env.TOUCHSTONE_SAML_DECRYPTION_PRIVATE_KEY
+    privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY
   }, (profile, done) => done(null, profile)))
 } else {
   // default to google auth
@@ -95,7 +94,7 @@ router.get('/auth/redirect', passport.authenticate(authStrategy, {failureRedirec
 router.get('/metadata', function(req, res) {
   if (isTouchstoneSamlAuth) {
     res.type('application/xml')
-    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata()))
+    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata(process.env.TOUCHSTONE_SAML_CERTIFICATE)))
   }
   else {
     res.redirect(formatUrl('/'))

--- a/userAuth.js
+++ b/userAuth.js
@@ -12,8 +12,6 @@ const {stringTemplate: template, formatUrl} = require('./utils')
 
 const router = require('express-promise-router')()
 const domains = new Set(process.env.APPROVED_DOMAINS.split(/,\s?/g))
-const samlDecryptionPrivateKey = process.env.TOUCHSTONE_SAML_PRIVATE_KEY
-const samlDecryptionPublicCert = process.env.TOUCHSTONE_SAML_PUBLIC_CERT
 
 const authStrategies = ['google', 'Slack', 'Touchstone']
 let authStrategy = process.env.OAUTH_STRATEGY
@@ -44,8 +42,9 @@ if (isSlackOauth) {
     path: callbackURL,
     entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
     issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
-    cert: samlDecryptionPublicCert,
-    privateKey: samlDecryptionPrivateKey,
+    cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
+    privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY,
+    decryptionPvk: process.env.TOUCHSTONE_SAML_DECRYPTION_PRIVATE_KEY
   }, (profile, done) => done(null, profile)))
 } else {
   // default to google auth
@@ -96,7 +95,7 @@ router.get('/auth/redirect', passport.authenticate(authStrategy, {failureRedirec
 router.get('/metadata', function(req, res) {
   if (isTouchstoneSamlAuth) {
     res.type('application/xml')
-    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata(samlDecryptionPublicCert)))
+    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata()))
   }
   else {
     res.redirect(formatUrl('/'))

--- a/userAuth.js
+++ b/userAuth.js
@@ -26,25 +26,38 @@ const isSlackOauth = authStrategy === 'Slack'
 const isTouchstoneSamlAuth = authStrategy === 'Touchstone'
 if (isSlackOauth) {
   passport.use(new SlackStrategy({
-    clientID: process.env.SLACK_CLIENT_ID,
-    clientSecret: process.env.SLACK_CLIENT_SECRET,
-    skipUserProfile: false,
-    callbackURL,
-    scope: ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team', 'identity.email']
-  },
-  (accessToken, refreshToken, profile, done) => {
-    // optionally persist user data into a database
-    done(null, profile)
-  }
+      clientID: process.env.SLACK_CLIENT_ID,
+      clientSecret: process.env.SLACK_CLIENT_SECRET,
+      skipUserProfile: false,
+      callbackURL,
+      scope: ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team', 'identity.email']
+    },
+    (accessToken, refreshToken, profile, done) => {
+      // optionally persist user data into a database
+      done(null, profile)
+    }
   ))
-} else if (isTouchstoneSamlAuth){
+} else if (isTouchstoneSamlAuth) {
   passport.use(new touchstoneSamlStrategy({
-    path: callbackURL,
-    entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
-    issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
-    cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
-    privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY
-  }, (profile, done) => done(null, profile)))
+      callbackUrl: callbackURL,
+      entryPoint: process.env.TOUCHSTONE_SAML_ENTRYPOINT_URL,
+      issuer: process.env.TOUCHSTONE_SAML_CERT_ISSUER,
+      cert: process.env.TOUCHSTONE_SAML_CERTIFICATE,
+      privateKey: process.env.TOUCHSTONE_SAML_PRIVATE_KEY,
+      decryptionPvk: process.env.TOUCHSTONE_SAML_DECRYPTION_PRIVATE_KEY,
+      wantAssertionsSigned: true,
+      metadataOrganization: {
+        OrganizationName: {'#text': process.env.TOUCHSTONE_SAML_ORG_NAME},
+        OrganizationDisplayName: {'#text': process.env.TOUCHSTONE_SAML_ORG_DISPLAY_NAME},
+        OrganizationURL: {'#text': process.env.TOUCHSTONE_SAML_ORG_URL}
+      },
+      metadataContactPerson: [{
+        '@contactType': 'support',
+        GivenName: process.env.TOUCHSTONE_SAML_CONTACT_NAME,
+        EmailAddress: process.env.TOUCHSTONE_SAML_CONTACT_EMAIL
+      }]
+    },
+    (profile, done) => done(null, profile)))
 } else {
   // default to google auth
   passport.use(new GoogleStrategy.Strategy({
@@ -91,12 +104,14 @@ router.get('/auth/redirect', passport.authenticate(authStrategy, {failureRedirec
   res.redirect(req.session.authRedirect || formatUrl('/'))
 })
 
-router.get('/metadata', function(req, res) {
+router.get('/metadata', function (req, res) {
   if (isTouchstoneSamlAuth) {
     res.type('application/xml')
-    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata(process.env.TOUCHSTONE_SAML_CERTIFICATE)))
-  }
-  else {
+    res.send((touchstoneSamlStrategy.generateServiceProviderMetadata(
+      process.env.TOUCHSTONE_SAML_MD_DECRYPTION_CERT,
+      process.env.TOUCHSTONE_SAML_MD_SIGNING_CERT
+    )))
+  } else {
     res.redirect(formatUrl('/'))
   }
 })


### PR DESCRIPTION
# What are the relevant tickets?
Closes #4 


# Description (What does it do?)
Added an auth strategy for SAML to support Touchstone. Modified authenticate method and email to take into account the addition of a new strategy. This also supports the creation of the metadata page within the application.


# How can this be tested?
Sar has contacted IS&T in order to get the credentials created and registered as well as set up a QA environment for us to test this in.

A user should be able to click the touchstone login button and be logged in as their touchstone user successfully.


## Checklist:
- [ ] Get touchstone credentials from IS&T
- [ ] Create env variables to support this
- [ ] Test on QA
